### PR TITLE
move configuration structure for all profiles to application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,17 @@ logging:
     com:
       hedvig: DEBUG
 
+cloud:
+  aws:
+    region.static: eu-central-1
+    stack.auto: false
+
 spring:
+  datasource:
+    platform: POSTGRESQL
+    url: ${POSTGRES_URL}/claims
+    username: ${POSTGRES_USERNAME}
+    password: ${POSTGRES_PASSWORD}
   jpa:
     generate-ddl: true
     properties:
@@ -25,6 +35,49 @@ spring:
   jackson:
     serialization:
       write_dates_as_timestamps: false
-
   main:
     allow-bean-definition-overriding: true
+  servlet:
+    multipart:
+      max-file-size: 512MB
+      max-request-size: 512MB
+
+---
+spring:
+  profiles: production, staging
+
+cloud.aws.credentials.instanceProfile: true
+claims:
+  claimFileUploadBucketName: ${CLAIMS_FILE_UPLOAD_BUCKET}
+  voiceRecordingBucketName: ${CLAIMS_VOICE_RECORDING_BUCKET}
+google:
+  storage.projectId: ${GOOGLE_STORAGE_PROJECTID}
+  storage.rawAudioBucketName: ${GOOGLE_STORAGE_RAW_AUDIO_BUCKET}
+hedvig:
+  chat.s3Bucket: ${HEDVIG_CHAT_S3BUCKET}
+  productPricing.url: product-pricing
+  member-service.url: member-service
+customerio.apiKey: ${CUSTOMERIO_APIKEY}
+customerio.siteId: ${CUSTOMERIO_SITEID}
+
+---
+spring:
+  profiles: staging
+
+server.port: 80 # only 80 for staging
+
+---
+spring:
+  profiles: development, test
+
+cloud.credentials.useDefaultAwsCredentialsChain: true
+claims:
+  claimFileUploadBucketName: com-hedvig-claims-files
+  voiceRecordingBucketName: hedvig-app-uploads-staging # why is this called staging when staging uses a different one?
+hedvig:
+  chat.s3Bucket: hedvig-app-uploads-staging
+  productPricing.url: http://localhost:4085
+  member-service.url: http://localhost:4084
+google:
+  storage.projectId: hedvig-test
+  storage.rawAudioBucketName: hedvig_speech_to_text_raw_audio


### PR DESCRIPTION
# Jira Issue: [HVG-823]

## What?
Similarly to already done in underwriter, move all the configuration into the same `application.yml` file, except for the secrets, which are injected through environment variables.

## Why?
This makes us able to check in the minimum necessary configuration needed to actually run claims without needing an `application-development.yml` file.

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally


[HVG-823]: https://hedvig.atlassian.net/browse/HVG-823