### PR TITLE
make the Dockerfile build the artifact, not only assemble an image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-##### Dependencies stage ####
+##### Dependencies stage #####
 FROM maven:3.6.3-amazoncorretto-11 AS dependencies
 
 # Resolve dependencies and cache them
@@ -7,7 +7,7 @@ COPY pom.xml /
 RUN mvn dependency:go-offline
 
 
-##### Build stage ####
+##### Build stage #####
 FROM dependencies AS build
 
 # Copy application source and build it
@@ -15,7 +15,7 @@ COPY src/main /src/main
 RUN mvn clean package
 
 
-##### Test stage ####
+##### Test stage #####
 FROM dependencies AS test
 
 # Copy test source and build+run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-##### Build stage ####
-FROM maven:3.6.3-amazoncorretto-11 AS build
+
+##### Dependencies stage ####
+FROM maven:3.6.3-amazoncorretto-11 AS dependencies
 
 # Resolve dependencies and cache them
 COPY pom.xml /
 RUN mvn dependency:go-offline
 
+
+##### Build stage ####
+FROM dependencies AS build
+
 # Copy application source and build it
 COPY src/main /src/main
 RUN mvn clean package
 
+
+##### Test stage ####
+FROM dependencies AS test
+
 # Copy test source and build+run tests
 COPY src/test /src/test
+COPY --from=build /target /target
 RUN mvn test
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,31 @@
-FROM openjdk:10.0.2-13-jdk-slim-sid
+##### Build stage ####
+FROM maven:3.6.3-amazoncorretto-11 AS build
 
-ADD target/claims-service-0.0.1-SNAPSHOT.jar /
+# Resolve dependencies and cache them
+COPY pom.xml /
+RUN mvn dependency:go-offline
 
-RUN apt update && apt -y install ffmpeg
+# Copy application source and build it
+COPY src/main /src/main
+RUN mvn clean package
 
-ENTRYPOINT java -jar claims-service-0.0.1-SNAPSHOT.jar
+# Copy test source and build+run tests
+COPY src/test /src/test
+RUN mvn test
+
+
+##### Assemble artifact #####
+FROM amazoncorretto:11-alpine AS assemble
+
+# Fetch the datadog agent
+RUN apk --no-cache add curl
+RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
+
+# Install ffmpeg
+RUN apk --no-cache add ffmpeg
+
+# Copy the jar from build stage to this one
+COPY --from=build /target/claims-service-0.0.1-SNAPSHOT.jar /
+
+# Define entry point
+ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar claims-service-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
# Jira Issue: [HVG-902]

## What?
Make the `Dockerfile` have the power to build, not only assemble the image.

## Why?
Now we can remove the specific `claims` pipeline and reuse the generic `docker build` one in Codefresh.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally


[HVG-902]: https://hedvig.atlassian.net/browse/HVG-902