### PR TITLE
Fixed naming issue that was causing a DTO to not load

### DIFF
--- a/src/main/java/com/hedvig/claims/payments/ClaimPaymentService.kt
+++ b/src/main/java/com/hedvig/claims/payments/ClaimPaymentService.kt
@@ -49,7 +49,7 @@ class ClaimPaymentService(
             return CreatePaymentOutcome.FORBIDDEN
         }
 
-        if (!request.sanctionCheckSkipped && (memberStatus == SanctionStatus.Undetermined || memberStatus == SanctionStatus.PartialHit)) {
+        if (!request.sanctionListSkipped && (memberStatus == SanctionStatus.Undetermined || memberStatus == SanctionStatus.PartialHit)) {
             return CreatePaymentOutcome.FORBIDDEN
         }
 
@@ -73,7 +73,7 @@ class ClaimPaymentService(
                 request.note,
                 request.exGratia,
                 request.handlerReference,
-                request.sanctionCheckSkipped
+                request.sanctionListSkipped
             )
         )
 

--- a/src/main/java/com/hedvig/claims/web/dto/CreatePaymentDto.kt
+++ b/src/main/java/com/hedvig/claims/web/dto/CreatePaymentDto.kt
@@ -10,5 +10,5 @@ data class CreatePaymentDto(
     val exGratia: Boolean,
     val type: PaymentType,
     val handlerReference: String,
-    val sanctionCheckSkipped: Boolean
+    val sanctionListSkipped: Boolean
 )


### PR DESCRIPTION
# Jira Issue: []

## What?
- sanctionCheckSkipped on claims-service vs sanctionListSkipped in back-office.

## Why?
https://github.com/HedvigInsurance/back-office/pull/331/files#diff-21a3792ac3d4d6db0eac65a8190a166ab17d5606510f15de27e7745c9a50f763

Removed ClaimPaymentRequest which contained boolean `sanctionCheckSkipped`. This was converted from `sanctionListSkipped` in the constructoy. 
The dto in claims-service did not match the `sanctionListSkipped` name that the back-office `ClaimPayment` dto used. Instead it used the name from `ClaimPaymentRequest`.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally
