### PR TITLE
Chore: Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.14.RELEASE</version>
+    <version>2.3.8.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -23,7 +23,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>9</java.version>
-    <kotlin.version>1.3.70</kotlin.version>
+    <kotlin.version>1.4.30</kotlin.version>
     <kotlin.code.style>official</kotlin.code.style>
     <axon.version>3.3.7</axon.version>
   </properties>
@@ -33,14 +33,14 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Greenwich.SR5</version>
+        <version>Hoxton.SR10</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>5.4.0</version>
+        <version>16.4.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.22</version>
+      <version>1.18.18</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.16.1</version>
+      <version>3.19.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.195</version>
+      <version>1.4.200</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>org.zalando</groupId>
       <artifactId>jackson-datatype-money</artifactId>
-      <version>1.0.0</version>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>5.0</version>
+      <version>6.6</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -179,22 +179,19 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-kubernetes</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-kubernetes-config</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-kubernetes-ribbon</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry-spring</artifactId>
-      <version>1.6.7</version>
+      <version>4.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -208,22 +205,22 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger2</artifactId>
-      <version>2.9.2</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-swagger-ui</artifactId>
-      <version>2.9.2</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.23.1-GA</version>
+      <version>3.27.0-GA</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -257,7 +254,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.415</version>
+      <version>1.11.954</version>
       <scope>compile</scope>
     </dependency>
 
@@ -278,7 +275,7 @@
     <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-52</artifactId>
-      <version>2.9.10</version>
+      <version>2.10.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/hedvig/claims/config/SentryConfig.java
+++ b/src/main/java/com/hedvig/claims/config/SentryConfig.java
@@ -1,23 +1,12 @@
 package com.hedvig.claims.config;
 
-import io.sentry.spring.SentryExceptionResolver;
-import io.sentry.spring.SentryServletContextInitializer;
-import org.springframework.boot.web.servlet.ServletContextInitializer;
-import org.springframework.context.annotation.Bean;
+import io.sentry.spring.EnableSentry;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 
+@EnableSentry()
 @Configuration
 @Profile("production")
 public class SentryConfig {
-  @Bean
-  public HandlerExceptionResolver sentryExceptionResolver() {
-    return new SentryExceptionResolver();
-  }
 
-  @Bean
-  public ServletContextInitializer sentryServletContextInitializer() {
-    return new SentryServletContextInitializer();
-  }
 }

--- a/src/main/java/com/hedvig/claims/query/ClaimReportHistoryEntity.java
+++ b/src/main/java/com/hedvig/claims/query/ClaimReportHistoryEntity.java
@@ -1,17 +1,18 @@
 package com.hedvig.claims.query;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
-import javax.persistence.Entity;
-import javax.persistence.Id;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 @Entity
 public class ClaimReportHistoryEntity {
   @Id

--- a/src/main/java/com/hedvig/claims/web/LogRequestFilter.java
+++ b/src/main/java/com/hedvig/claims/web/LogRequestFilter.java
@@ -1,7 +1,7 @@
 package com.hedvig.claims.web;
 
 import io.sentry.Sentry;
-import io.sentry.event.UserBuilder;
+import io.sentry.protocol.User;
 import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -31,7 +31,9 @@ public class LogRequestFilter implements Filter {
         String hedvigToken = httpRequest.getHeader("hedvig.token");
         if (hedvigToken != null) {
           MDC.put("memberId", hedvigToken);
-          Sentry.getContext().setUser(new UserBuilder().setId(hedvigToken).build());
+          User user = new User();
+          user.setId(hedvigToken);
+          Sentry.setUser(user);
         }
       }
       chain.doFilter(request, response);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,5 +5,6 @@ spring:
     properties:
       hibernate:
         order_by.default_null_ordering: last
+        dialect: org.hibernate.dialect.PostgreSQLDialect
   datasource:
     url: jdbc:h2:mem:claims;MODE=PostgreSQL;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
Test H2 DB configuration needed a new dialect due to a change in the way Spring handled table names.
ClaimReportHistoryEntity required a no-args constructor in order to work.
Sentry works in a different way now. Changed the way an user is built in LogRequestFilter.
SentryConfig works by annotation instead of methods.

Ideally, this could use an extra pair or two of eyes for testing.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally
