### PR TITLE
New upcasters to cater for MonetaryAmount class change.

### DIFF
--- a/src/main/java/com/hedvig/claims/config/AxonConfiguration.java
+++ b/src/main/java/com/hedvig/claims/config/AxonConfiguration.java
@@ -1,10 +1,13 @@
 package com.hedvig.claims.config;
 
 import com.hedvig.claims.events.upcast.AutomaticPaymentAddedEvent_v1;
+import com.hedvig.claims.events.upcast.AutomaticPaymentAddedEvent_v2;
 import com.hedvig.claims.events.upcast.ClaimCreatedEvent_v1;
 import com.hedvig.claims.events.upcast.ClaimFileUploadedEventUpcaster_v1;
 import com.hedvig.claims.events.upcast.ExpensePaymentAddedEvent_v1;
+import com.hedvig.claims.events.upcast.ExpensePaymentAddedEvent_v2;
 import com.hedvig.claims.events.upcast.IndemnityCostPaymentAddedEvent_v1;
+import com.hedvig.claims.events.upcast.IndemnityCostPaymentAddedEvent_v2;
 import com.hedvig.claims.events.upcast.PaymentAddedEvent_v1;
 import com.hedvig.claims.events.upcast.PaymentAddedEvent_v2;
 import com.hedvig.claims.events.upcast.PaymentAddedEvent_v3;
@@ -28,8 +31,11 @@ public class AxonConfiguration {
             new PaymentAddedEvent_v3(),
             new ClaimFileUploadedEventUpcaster_v1(),
             new AutomaticPaymentAddedEvent_v1(),
+            new AutomaticPaymentAddedEvent_v2(),
             new IndemnityCostPaymentAddedEvent_v1(),
-            new ExpensePaymentAddedEvent_v1()
+            new IndemnityCostPaymentAddedEvent_v2(),
+            new ExpensePaymentAddedEvent_v1(),
+            new ExpensePaymentAddedEvent_v2()
         );
     }
 

--- a/src/main/java/com/hedvig/claims/events/AutomaticPaymentAddedEvent.java
+++ b/src/main/java/com/hedvig/claims/events/AutomaticPaymentAddedEvent.java
@@ -8,7 +8,7 @@ import org.axonframework.serialization.Revision;
 
 @Value
 @AllArgsConstructor
-@Revision("1.0")
+@Revision("2.0")
 public class AutomaticPaymentAddedEvent {
     public String Id;
     public String claimId;

--- a/src/main/java/com/hedvig/claims/events/ExpensePaymentAddedEvent.kt
+++ b/src/main/java/com/hedvig/claims/events/ExpensePaymentAddedEvent.kt
@@ -2,7 +2,9 @@ package com.hedvig.claims.events
 
 import com.hedvig.claims.query.Carrier
 import javax.money.MonetaryAmount
+import org.axonframework.serialization.Revision
 
+@Revision("2.0")
 class ExpensePaymentAddedEvent(
     val id: String,
     val claimId: String,

--- a/src/main/java/com/hedvig/claims/events/IndemnityCostPaymentAddedEvent.kt
+++ b/src/main/java/com/hedvig/claims/events/IndemnityCostPaymentAddedEvent.kt
@@ -4,7 +4,7 @@ import com.hedvig.claims.query.Carrier
 import org.axonframework.serialization.Revision
 import javax.money.MonetaryAmount
 
-@Revision("1.0")
+@Revision("2.0")
 class IndemnityCostPaymentAddedEvent (
     val id: String,
     val claimId: String,

--- a/src/main/java/com/hedvig/claims/events/upcast/AutomaticPaymentAddedEvent_v2.kt
+++ b/src/main/java/com/hedvig/claims/events/upcast/AutomaticPaymentAddedEvent_v2.kt
@@ -1,0 +1,51 @@
+package com.hedvig.claims.events.upcast
+
+import com.hedvig.claims.events.AutomaticPaymentAddedEvent
+import lombok.Value
+import org.axonframework.serialization.SimpleSerializedType
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation
+import org.axonframework.serialization.upcasting.event.SingleEventUpcaster
+import org.dom4j.Document
+
+@Value
+class AutomaticPaymentAddedEvent_v2 : SingleEventUpcaster() {
+    override fun canUpcast(intermediateRepresentation: IntermediateEventRepresentation): Boolean {
+        return intermediateRepresentation.type == targetType
+    }
+
+    override fun doUpcast(intermediateRepresentation: IntermediateEventRepresentation): IntermediateEventRepresentation {
+        return intermediateRepresentation.upcastPayload(
+            outputType,
+            Document::class.java
+        ) { document ->
+            val rootElement = document.rootElement
+            val amount = rootElement.element("amount")
+            val amountCurrency = amount.element("currency")
+            val amountAttribute = amountCurrency.attribute("class")
+            if (amountAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                amountCurrency.remove(amountAttribute)
+                amountCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            val deductible = rootElement.element("deductible")
+            val deductibleCurrency = deductible.element("currency")
+            val deductibleAttribute = deductibleCurrency.attribute("class")
+            if (deductibleAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                deductibleCurrency.remove(deductibleAttribute)
+                deductibleCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            document
+        }
+    }
+
+    companion object {
+        private val targetType = SimpleSerializedType(
+            AutomaticPaymentAddedEvent::class.java.typeName, "1.0"
+        )
+
+        private val outputType = SimpleSerializedType(
+            AutomaticPaymentAddedEvent::class.java.typeName, "2.0"
+        )
+    }
+}

--- a/src/main/java/com/hedvig/claims/events/upcast/ExpensePaymentAddedEvent_v2.kt
+++ b/src/main/java/com/hedvig/claims/events/upcast/ExpensePaymentAddedEvent_v2.kt
@@ -1,0 +1,51 @@
+package com.hedvig.claims.events.upcast
+
+import com.hedvig.claims.events.ExpensePaymentAddedEvent
+import lombok.Value
+import org.axonframework.serialization.SimpleSerializedType
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation
+import org.axonframework.serialization.upcasting.event.SingleEventUpcaster
+import org.dom4j.Document
+
+@Value
+class ExpensePaymentAddedEvent_v2 : SingleEventUpcaster() {
+    override fun canUpcast(intermediateRepresentation: IntermediateEventRepresentation): Boolean {
+        return intermediateRepresentation.type == targetType
+    }
+
+    override fun doUpcast(intermediateRepresentation: IntermediateEventRepresentation): IntermediateEventRepresentation {
+        return intermediateRepresentation.upcastPayload(
+            outputType,
+            Document::class.java
+        ) { document ->
+            val rootElement = document.rootElement
+            val amount = rootElement.element("amount")
+            val amountCurrency = amount.element("currency")
+            val amountAttribute = amountCurrency.attribute("class")
+            if (amountAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                amountCurrency.remove(amountAttribute)
+                amountCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            val deductible = rootElement.element("deductible")
+            val deductibleCurrency = deductible.element("currency")
+            val deductibleAttribute = deductibleCurrency.attribute("class")
+            if (deductibleAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                deductibleCurrency.remove(deductibleAttribute)
+                deductibleCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            document
+        }
+    }
+
+    companion object {
+        private val targetType = SimpleSerializedType(
+            ExpensePaymentAddedEvent::class.java.typeName, "1.0"
+        )
+
+        private val outputType = SimpleSerializedType(
+            ExpensePaymentAddedEvent::class.java.typeName, "2.0"
+        )
+    }
+}

--- a/src/main/java/com/hedvig/claims/events/upcast/IndemnityCostPaymentAddedEvent_v2.kt
+++ b/src/main/java/com/hedvig/claims/events/upcast/IndemnityCostPaymentAddedEvent_v2.kt
@@ -1,0 +1,51 @@
+package com.hedvig.claims.events.upcast
+
+import com.hedvig.claims.events.IndemnityCostPaymentAddedEvent
+import lombok.Value
+import org.axonframework.serialization.SimpleSerializedType
+import org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation
+import org.axonframework.serialization.upcasting.event.SingleEventUpcaster
+import org.dom4j.Document
+
+@Value
+class IndemnityCostPaymentAddedEvent_v2 : SingleEventUpcaster() {
+    override fun canUpcast(intermediateRepresentation: IntermediateEventRepresentation): Boolean {
+        return intermediateRepresentation.type == targetType
+    }
+
+    override fun doUpcast(intermediateRepresentation: IntermediateEventRepresentation): IntermediateEventRepresentation {
+        return intermediateRepresentation.upcastPayload(
+            outputType,
+            Document::class.java
+        ) { document ->
+            val rootElement = document.rootElement
+            val amount = rootElement.element("amount")
+            val amountCurrency = amount.element("currency")
+            val amountAttribute = amountCurrency.attribute("class")
+            if (amountAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                amountCurrency.remove(amountAttribute)
+                amountCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            val deductible = rootElement.element("deductible")
+            val deductibleCurrency = deductible.element("currency")
+            val deductibleAttribute = deductibleCurrency.attribute("class")
+            if (deductibleAttribute.value == "org.javamoney.moneta.internal.JDKCurrencyAdapter") {
+                deductibleCurrency.remove(deductibleAttribute)
+                deductibleCurrency.addAttribute("class", "org.javamoney.moneta.spi.JDKCurrencyAdapter")
+            }
+
+            document
+        }
+    }
+
+    companion object {
+        private val targetType = SimpleSerializedType(
+            IndemnityCostPaymentAddedEvent::class.java.typeName, "1.0"
+        )
+
+        private val outputType = SimpleSerializedType(
+            IndemnityCostPaymentAddedEvent::class.java.typeName, "2.0"
+        )
+    }
+}


### PR DESCRIPTION

# Jira Issue: []

## What?
-

## Why?
`org.javamoney:moneta:1.4.2` 
changed 
`org.javamoney.moneta.internal.JDKCurrencyAdapter` 
to 
`org.javamoney.moneta.spi.JDKCurrencyAdapter`.
This broke Axon because it uses this class inside it's eventStores. This resulted in an upcaster.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally
