### PR TITLE
Added delay between transcription requests

### DIFF
--- a/src/main/java/com/hedvig/claims/web/BackfillController.kt
+++ b/src/main/java/com/hedvig/claims/web/BackfillController.kt
@@ -26,7 +26,7 @@ class BackfillController(
         log.info("Backfilling ${list.size} claims")
         var numTranscribed = 0
         list.forEach {
-            Thread.sleep(5)
+            Thread.sleep(50)
             try {
                 log.info("Backfilling audio for claim ${it.id} -  Started")
                 val result = speechToTextService.convertSpeechToText(it.audioURL, it.id)
@@ -46,7 +46,8 @@ class BackfillController(
                 log.error("Backfilling audio for claim ${it.id} - Caught exception transcribing audio", e)
             }
         }
-        log.info("Backfilling finished with $numTranscribed successfully transcribed recordings")
+        log.info("Backfilling finished with $numTranscribed successfully transcribed recordings " +
+                "and ${list.size - numTranscribed} exceptions")
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/hedvig/claims/web/BackfillController.kt
+++ b/src/main/java/com/hedvig/claims/web/BackfillController.kt
@@ -23,7 +23,10 @@ class BackfillController(
     @PostMapping("/audioTranscription")
     fun backfillAudioTranscription() {
         val list = claimsRepository.findAllByTranscriptionsIsNull()
+        log.info("Backfilling ${list.size} claims")
+        var numTranscribed = 0
         list.forEach {
+            Thread.sleep(5)
             try {
                 log.info("Backfilling audio for claim ${it.id} -  Started")
                 val result = speechToTextService.convertSpeechToText(it.audioURL, it.id)
@@ -38,10 +41,12 @@ class BackfillController(
                     )
                 }
                 log.info("Backfilling audio for claim ${it.id}  -  Ended")
+                numTranscribed++
             } catch (e: Exception) {
                 log.error("Backfilling audio for claim ${it.id} - Caught exception transcribing audio", e)
             }
         }
+        log.info("Backfilling finished with $numTranscribed successfully transcribed recordings")
     }
 
     @GetMapping("/test")


### PR DESCRIPTION
# Jira Issue: []

## What?
- Added a time delay between requests in the backfiller
- Also added some more logging to see how many recordings were successfully transcribed

## Why?
- The backfiller was throwing a lot of exceptions, trying to see if this will fix it

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally
