### PR TITLE
Claim note handler reference

### DIFF
--- a/src/main/java/com/hedvig/claims/aggregates/ClaimsAggregate.java
+++ b/src/main/java/com/hedvig/claims/aggregates/ClaimsAggregate.java
@@ -196,6 +196,7 @@ public class ClaimsAggregate {
         ne.setId(command.getId());
         ne.setText(command.getText());
         ne.setUserId(this.userId);
+        ne.setHandlerReference(command.getHandlerReference());
         apply(ne);
     }
 
@@ -540,6 +541,7 @@ public class ClaimsAggregate {
         note.text = event.getText();
         note.userId = event.getUserId();
         note.date = event.getDate();
+        note.handlerReference = event.getHandlerReference();
         notes.add(note);
     }
 

--- a/src/main/java/com/hedvig/claims/aggregates/Note.java
+++ b/src/main/java/com/hedvig/claims/aggregates/Note.java
@@ -12,4 +12,5 @@ public class Note {
   public String text;
   public String userId;
   public String fileURL;
+  public String handlerReference;
 }

--- a/src/main/java/com/hedvig/claims/commands/AddNoteCommand.java
+++ b/src/main/java/com/hedvig/claims/commands/AddNoteCommand.java
@@ -18,9 +18,10 @@ public class AddNoteCommand {
   public String text;
   public String userId;
   public String fileURL;
+  public String handlerReference; // optional email to IEX person
 
   public AddNoteCommand(
-      String id, String claimID, LocalDateTime date, String text, String userId, String fileURL) {
+      String id, String claimID, LocalDateTime date, String text, String userId, String fileURL, String handlerReference) {
     log.info("InitiateClaimCommand");
     this.id = id;
     this.claimID = claimID;
@@ -28,6 +29,7 @@ public class AddNoteCommand {
     this.text = text;
     this.userId = userId;
     this.fileURL = fileURL;
+    this.handlerReference = handlerReference;
     log.info(this.toString());
   }
 }

--- a/src/main/java/com/hedvig/claims/events/NoteAddedEvent.java
+++ b/src/main/java/com/hedvig/claims/events/NoteAddedEvent.java
@@ -12,4 +12,5 @@ public class NoteAddedEvent {
   public String text;
   public String userId;
   public String fileURL;
+  public String handlerReference; // optional email to iex person
 }

--- a/src/main/java/com/hedvig/claims/payments/ClaimPaymentService.kt
+++ b/src/main/java/com/hedvig/claims/payments/ClaimPaymentService.kt
@@ -61,7 +61,8 @@ class ClaimPaymentService(
                 LocalDateTime.now(),
                 request.note,
                 memberId,
-                claim.audioURL
+                claim.audioURL,
+                request.handlerReference
             )
         )
 

--- a/src/main/java/com/hedvig/claims/query/ClaimsEventListener.java
+++ b/src/main/java/com/hedvig/claims/query/ClaimsEventListener.java
@@ -140,6 +140,7 @@ public class ClaimsEventListener {
         n.fileURL = e.getFileURL();
         n.text = e.getText();
         n.userId = e.getUserId();
+        n.handlerReference = e.getHandlerReference();
         claim.addNote(n);
 
         Event ev = createEvent(e, "Note added:" + n.text);

--- a/src/main/java/com/hedvig/claims/web/InternalController.kt
+++ b/src/main/java/com/hedvig/claims/web/InternalController.kt
@@ -13,7 +13,6 @@ import com.hedvig.claims.commands.UpdateClaimsReserveCommand
 import com.hedvig.claims.commands.UpdateClaimsStateCommand
 import com.hedvig.claims.commands.UpdateEmployeeClaimStatusCommand
 import com.hedvig.claims.commands.UploadClaimFileCommand
-import com.hedvig.claims.commands.SelectedPayoutDetails
 import com.hedvig.claims.payments.ClaimPaymentService
 import com.hedvig.claims.query.ClaimEntity
 import com.hedvig.claims.query.ClaimFileRepository
@@ -58,6 +57,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -193,7 +193,7 @@ class InternalController(
     }
 
     @PostMapping("/addnote")
-    fun addNote(@RequestBody note: NoteDTO): ResponseEntity<*> {
+    fun addNote(@RequestBody note: NoteDTO, @RequestHeader("Authorization") handlerReferenceEmail: String?): ResponseEntity<*> {
         val uuid = UUID.randomUUID()
         val command = AddNoteCommand(
             uuid.toString(),
@@ -201,7 +201,8 @@ class InternalController(
             LocalDateTime.now(),
             note.text,
             note.userId,
-            note.fileURL
+            note.fileURL,
+            handlerReferenceEmail
         )
         commandBus.sendAndWait<Any>(command)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build<Any>()

--- a/src/main/java/com/hedvig/claims/web/dto/ClaimDTO.java
+++ b/src/main/java/com/hedvig/claims/web/dto/ClaimDTO.java
@@ -74,7 +74,7 @@ public class ClaimDTO extends HedvigBackofficeDTO {
                     p.payoutStatus));
         }
         for (Note n : c.notes) {
-            notes.add(new NoteDTO(n.id, c.id, n.date, n.userId, n.text, n.fileURL));
+            notes.add(new NoteDTO(n.id, c.id, n.date, n.userId, n.text, n.fileURL, n.handlerReference));
         }
 
         for (Transcription t : c.transcriptions) {

--- a/src/main/java/com/hedvig/claims/web/dto/NoteDTO.java
+++ b/src/main/java/com/hedvig/claims/web/dto/NoteDTO.java
@@ -6,6 +6,7 @@ public class NoteDTO extends HedvigBackofficeDTO {
 
   public String text;
   public String fileURL;
+  public String handlerReference;
 
   public NoteDTO() {}
 
@@ -15,12 +16,14 @@ public class NoteDTO extends HedvigBackofficeDTO {
       LocalDateTime registrationDate,
       String userId,
       String text,
-      String fileURL) {
+      String fileURL,
+      String handlerReference) {
     this.id = noteId;
     this.claimID = claimsId;
     this.date = registrationDate;
     this.userId = userId;
     this.text = text;
     this.fileURL = fileURL;
+    this.handlerReference = handlerReference;
   }
 }


### PR DESCRIPTION
## What?
- Add who added the claim note to notes

## Why?
- So we can really know who did what. We're already [sending the email from back-office](https://github.com/HedvigInsurance/back-office/blob/master/src/main/java/com/hedvig/backoffice/services/claims/ClaimsServiceClient.java#L68) so lets store that

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally
