### PR TITLE
Actually, don't store the token but rather set the email explicitly

### DIFF
--- a/src/main/java/com/hedvig/claims/web/InternalController.kt
+++ b/src/main/java/com/hedvig/claims/web/InternalController.kt
@@ -193,7 +193,7 @@ class InternalController(
     }
 
     @PostMapping("/addnote")
-    fun addNote(@RequestBody note: NoteDTO, @RequestHeader("Authorization") handlerReferenceEmail: String?): ResponseEntity<*> {
+    fun addNote(@RequestBody note: NoteDTO ): ResponseEntity<*> {
         val uuid = UUID.randomUUID()
         val command = AddNoteCommand(
             uuid.toString(),
@@ -202,7 +202,7 @@ class InternalController(
             note.text,
             note.userId,
             note.fileURL,
-            handlerReferenceEmail
+            note.handlerReference
         )
         commandBus.sendAndWait<Any>(command)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build<Any>()

--- a/src/main/java/com/hedvig/claims/web/InternalController.kt
+++ b/src/main/java/com/hedvig/claims/web/InternalController.kt
@@ -193,7 +193,7 @@ class InternalController(
     }
 
     @PostMapping("/addnote")
-    fun addNote(@RequestBody note: NoteDTO ): ResponseEntity<*> {
+    fun addNote(@RequestBody note: NoteDTO): ResponseEntity<*> {
         val uuid = UUID.randomUUID()
         val command = AddNoteCommand(
             uuid.toString(),


### PR DESCRIPTION
I thought the token was the email but it's apparently what it says it is - a jwt. So i figured let's just attach the employee's email from back office instead (PR for that comin' up).